### PR TITLE
Implement Ultrawide HUD fixes.

### DIFF
--- a/Monkey Patch/BlingMenuInstall.cpp
+++ b/Monkey Patch/BlingMenuInstall.cpp
@@ -16,7 +16,6 @@
 const char* ERROR_MESSAGE = "ERROR";
 // MainHooks.cpp
 void ToggleNoclip();
-void AspectRatioFix();
 void SlewModeToggle();
 void TeleportToWaypoint();
 void VehicleSpawner(const char* Name, const char* Var);
@@ -263,7 +262,7 @@ namespace BlingMenuInstall
        BlingMenuAddFuncCustom("Juiced", "Disable Cutscene black-bars", NULL, &BM_DisableCutSceneBlackBars, NULL);
        BlingMenuAddFuncCustom("Juiced", "Disable Fog", NULL, &BM_DisableFog, NULL);
        BlingMenuAddDouble("Juiced", "FOV Multiplier", &Render3D::FOVMultiplier, []() {
-           AspectRatioFix();
+           Render3D::AspectRatioFix();
            GameConfig::SetDoubleValue("Gameplay", "FOVMultiplier", Render3D::FOVMultiplier);
            }, 0.01, 0.1, 5.0);
        BlingMenuAddInt("Juiced", "Vehicle Auto Center Modifer", &Behavior::sticky_cam_timer_add, []() {

--- a/Monkey Patch/General/General.cpp
+++ b/Monkey Patch/General/General.cpp
@@ -831,12 +831,13 @@ void __declspec(naked) TextureCrashFixRemasteredByGroveStreetGames()
 #if !JLITE
 		}
 #endif
+		Render2D::vint_create_process_hook = safetyhook::create_mid(0x00B8BCC6, &Render2D::create_process_hook,safetyhook::MidHook::StartDisabled);
 		if (GameConfig::GetValue("Graphics", "FixUltrawideHUD", 1) >= 2) {
 			Logger::TypedLog(CHN_MOD, "Patching Ultrawide HUD %d \n", 2);
 			using namespace Render2D;
 			WriteRelCall(0x00D1EF2F, (UInt32)&SR2Ultrawide_HUDScale);
 			WriteRelCall(0x00D1F944, (UInt32)&SR2Ultrawide_HUDScale);
-			vint_create_process_hook = safetyhook::create_mid(0x00B8BCC6, &create_process_hook);
+			vint_create_process_hook.enable();
 		}
 		// LUA EXECUTE
 		patchBytesM((BYTE*)0x0075D5D6, (BYTE*)"\x68\x3A\x30\x7B\x02", 5);

--- a/Monkey Patch/General/General.cpp
+++ b/Monkey Patch/General/General.cpp
@@ -13,6 +13,7 @@ and / or run completely on startup or after we check everything else.*/
 #include "General.h"
 #include <safetyhook.hpp>
 #include "../Render/Render3D.h"
+#include "../Render/Render2D.h"
 namespace General {
 	bool DeletionMode;
 	const wchar_t* SaveMessage = L"Are you sure you want to delete this save?"; // ultimately, if we get extra strings to load, we should use a string label and request the string instead of hardcoding it
@@ -332,12 +333,91 @@ void __declspec(naked) TextureCrashFixRemasteredByGroveStreetGames()
 		buf.append(s, prevPos, s.size() - prevPos);
 		s.swap(buf);
 	}
+	char* currentModifiedBuffer = nullptr;
 
 	void VINT_DOC_luaLoadBuff(safetyhook::Context32& ctx) {
 		const char* buff = (const char*)ctx.ebp;
-		//const char* filename = (const char*)(ctx.esp + 0x14);
+		const char* filename = (const char*)(ctx.esp + 0x14);
 		size_t& sz = ctx.ecx;
 
+		if (Render2D::UltrawideFix) {
+			// Clean up previous buffer if it exists (regardless of which file it was for)
+			if (currentModifiedBuffer != nullptr) {
+				delete[] currentModifiedBuffer;
+				currentModifiedBuffer = nullptr;
+			}
+
+			// remove .lua
+			std::string cached_str = filename;
+			size_t dotPosition = cached_str.find(".lua");
+			if (dotPosition != std::string::npos) {
+				cached_str = cached_str.substr(0, dotPosition);
+			}
+
+			std::string customCode = "";
+			const char* lua_command = "vint_set_property(vint_object_find(\"%s\", 0, vint_document_find(\"%s\")), \"%s\", %f, %f)";
+
+			// re-center the HUD.
+			char buffer[512];
+			snprintf(buffer, sizeof(buffer), lua_command, "safe_frame", cached_str.c_str(), "anchor",
+				(Render2D::get_vint_x_resolution() - 1280) / 2.f, 0.f);
+			customCode += "\n";
+			customCode += buffer;
+
+			// Weird stuff on the screen you have to remove, also mayhem is re-stretched back.
+			if (cached_str == "hud") {
+				using namespace Render2D;
+				char extraBuffer[512];
+
+				snprintf(extraBuffer, sizeof(extraBuffer), lua_command, "extra_homie", "hud", "anchor",
+					(get_vint_x_resolution() - 1280) / 2.f, -500.f);
+				customCode += "\n";
+				customCode += extraBuffer;
+
+				snprintf(extraBuffer, sizeof(extraBuffer), lua_command, "mp_snatch_john", "hud", "anchor",
+					(get_vint_x_resolution() - 1280) / 2.f, -500.f);
+				customCode += "\n";
+				customCode += extraBuffer;
+
+				snprintf(extraBuffer, sizeof(extraBuffer), lua_command, "health_mini_grp", "hud", "anchor",
+					(get_vint_x_resolution() - 1280) / 2.f, -500.f);
+				customCode += "\n";
+				customCode += extraBuffer;
+
+				snprintf(extraBuffer, sizeof(extraBuffer), lua_command, "health_large_grp", "hud", "anchor",
+					(get_vint_x_resolution() - 1280) / 2.f, -500.f);
+				customCode += "\n";
+				customCode += extraBuffer;
+
+				snprintf(extraBuffer, sizeof(extraBuffer), lua_command, "mayhem_grp", "hud", "anchor",
+					-((get_vint_x_resolution() - 1280) / 2.f), 0.f);
+				customCode += "\n";
+				customCode += extraBuffer;
+
+				float weirdscale = 1.f / (Render2D::widescreenvalue / *Render2D::currentAR);
+				snprintf(extraBuffer, sizeof(extraBuffer), lua_command, "mayhem_grp", "hud", "scale",
+					weirdscale, 1.f);
+				customCode += "\n";
+				customCode += extraBuffer;
+			}
+
+			// If we have code to add
+			if (!customCode.empty()) {
+				// Create a new buffer
+				size_t customCodeLen = customCode.length();
+				size_t newSize = sz + customCodeLen + 1; // +1 for null terminator
+
+				currentModifiedBuffer = new char[newSize];
+				memcpy(currentModifiedBuffer, buff, sz);
+				memcpy(currentModifiedBuffer + sz, customCode.c_str(), customCodeLen + 1);
+
+				// Update the context
+				ctx.ebp = (DWORD)currentModifiedBuffer;
+				sz = newSize - 1;
+
+				printf("Modified %s with custom code\n", filename);
+			}
+		}
 		std::string convertedBuff(buff);
 
 		int* resX = (int*)(0xE8DF14);
@@ -389,7 +469,12 @@ void __declspec(naked) TextureCrashFixRemasteredByGroveStreetGames()
 			const_cast<char*>(buff)[sz] = '\0';
 		}
 	}
-
+	void CleanupModifiedScript() {
+		if (currentModifiedBuffer != nullptr) {
+			delete[] currentModifiedBuffer;
+			currentModifiedBuffer = nullptr;
+		}
+	}
 	bool __declspec(naked) VintGetGlobalBool(const char* Name)
 	{
 		_asm {
@@ -721,11 +806,22 @@ void __declspec(naked) TextureCrashFixRemasteredByGroveStreetGames()
 			Render3D::CMPatches_ClippysIdiotTextureCrashExceptionHandle.Apply(); // also not ideal, might have perfomance impact, implementation in Render3D.cpp
 		}
 #if !JLITE
-#if !RELOADED
-		if (GameConfig::GetValue("Debug", "PatchPauseMenuLua", 1)) {
+
+		if (GameConfig::GetValue("Debug", "Hook_lua_load_dynamic_script_buffer", 1)) {
 			static SafetyHookMid luaLoadBuffHook = safetyhook::create_mid(0x00CDE379, &VINT_DOC_luaLoadBuff);
+			if (GameConfig::GetValue("Graphics", "FixUltrawideHUD", 1) == 1) {
+				using namespace Render2D;
+				//SR2Ultrawide_hook = safetyhook::create_inline(0xD1C910, &SR2Ultrawide_HUDScale);
+				WriteRelCall(0x00D1EF2F, (UInt32)&SR2Ultrawide_HUDScale);
+				WriteRelCall(0x00D1F944, (UInt32)&SR2Ultrawide_HUDScale);
+			}
 		}
-#endif
+		if (GameConfig::GetValue("Graphics", "FixUltrawideHUD", 1) >= 2) {
+			using namespace Render2D;
+			WriteRelCall(0x00D1EF2F, (UInt32)&SR2Ultrawide_HUDScale);
+			WriteRelCall(0x00D1F944, (UInt32)&SR2Ultrawide_HUDScale);
+			vint_create_process_hook = safetyhook::create_mid(0x00B8BCC6, &create_process_hook);
+		}
 		// LUA EXECUTE
 		patchBytesM((BYTE*)0x0075D5D6, (BYTE*)"\x68\x3A\x30\x7B\x02", 5);
 		patchBytesM((BYTE*)0x0075D5B5, (BYTE*)"\x68\x3A\x30\x7B\x02", 5);

--- a/Monkey Patch/General/General.h
+++ b/Monkey Patch/General/General.h
@@ -30,4 +30,5 @@ namespace General {
 	int VintExecute(const char* Command);
 	wchar_t* RequestString(const wchar_t* Dest, const char* Label);
 	extern CMultiPatch CMPatches_TervelTextureCrashWorkaround_be_as_pe;
+	extern void CleanupModifiedScript();
 }

--- a/Monkey Patch/General/General.h
+++ b/Monkey Patch/General/General.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "../Patcher/CPatch.h"
 #include "../Patcher/CMultiPatch.h"
+#include <safetyhook.hpp>
 namespace General {
 	void TopWinMain();
 	void BottomWinMain();
@@ -31,4 +32,5 @@ namespace General {
 	wchar_t* RequestString(const wchar_t* Dest, const char* Label);
 	extern CMultiPatch CMPatches_TervelTextureCrashWorkaround_be_as_pe;
 	extern void CleanupModifiedScript();
+	extern SafetyHookMid cleanupBufferHook;
 }

--- a/Monkey Patch/General/General.h
+++ b/Monkey Patch/General/General.h
@@ -33,4 +33,5 @@ namespace General {
 	extern CMultiPatch CMPatches_TervelTextureCrashWorkaround_be_as_pe;
 	extern void CleanupModifiedScript();
 	extern SafetyHookMid cleanupBufferHook;
+	extern SafetyHookMid luaLoadBuffHook;
 }

--- a/Monkey Patch/MainHooks.cpp
+++ b/Monkey Patch/MainHooks.cpp
@@ -1275,6 +1275,7 @@ static bool modpackread = 0;
 #endif
 int RenderLoopStuff_Hacked()
 {
+	
 #if !JLITE
 	if (useJuicedOSD) {
 		PrintFrametime();

--- a/Monkey Patch/Render/Render2D.cpp
+++ b/Monkey Patch/Render/Render2D.cpp
@@ -212,6 +212,13 @@ namespace Render2D
 
 bool UltrawideFix = false;
 // Clippy TODO, maybe handle 16:10?
+std::thread RefreshHUD_thread;
+void RefreshHUD_loop() {
+	vint_create_process_hook.enable();
+	std::this_thread::sleep_for(std::chrono::seconds(4));
+	vint_create_process_hook.disable();
+}
+
 char SR2Ultrawide_HUDScale() {
 	
 	float currentX = (float)(*(unsigned int*)0x022f63f8);
@@ -234,10 +241,15 @@ char SR2Ultrawide_HUDScale() {
 	//SafeWrite32(0x00B87313 + 1, var2);
 	SafeWrite32(0x00625D09 + 2, (UInt32)&var2);
 	SafeWrite32(0x0062597F + 2, (UInt32)&var2);
+
+
+		RefreshHUD_thread = std::thread(RefreshHUD_loop);
+		RefreshHUD_thread.detach();
+
 	if (aspectRatio >= 1.79777777778f) {
 		Render3D::AspectRatioFix(true);
 	}
-	if (!vint_create_process_hook.enabled()) {
+	if ((GameConfig::GetValue("Graphics", "FixUltrawideHUD", 1) == 1)) {
 		if (aspectRatio <= 1.79777777778f) {
 #if JLITE
 			General::luaLoadBuffHook.disable();

--- a/Monkey Patch/Render/Render2D.cpp
+++ b/Monkey Patch/Render/Render2D.cpp
@@ -219,6 +219,21 @@ char SR2Ultrawide_HUDScale() {
 	char result;
 
 	float aspectRatio = currentX / currentY;
+
+	// Fucking tagging system cause yeah lets hard code the anchor for it?
+
+	int var = (int)(aspectRatio * 720.f);
+	static int var2;
+	 var2 = (int)(aspectRatio * 360.f);
+	SafeWrite32(0x00622571 + 1, var);
+	SafeWrite32(0x00625A2B + 2, var);
+	//SafeWrite32(0x00625F70 + 1, var);
+	//SafeWrite32(0x00755A21 + 1, var);
+	//SafeWrite32(0x00755C49 + 1, var);
+	//SafeWrite32(0x00B87313 + 1, var2);
+	//SafeWrite32(0x00B87313 + 1, var2);
+	SafeWrite32(0x00625D09 + 2, (UInt32)&var2);
+	SafeWrite32(0x0062597F + 2, (UInt32)&var2);
 	if (aspectRatio >= 1.79777777778f) {
 		Render3D::AspectRatioFix(true);
 	}
@@ -241,20 +256,6 @@ char SR2Ultrawide_HUDScale() {
 			UltrawideFix = true;
 		}
 	}
-
-	// Fucking tagging system cause yeah lets hard code the anchor for it?
-
-	int var = (int)(aspectRatio * 720.f);
-	int var2 = (int)(aspectRatio * 360.f);
-	SafeWrite32(0x00622571 + 1, var);
-	SafeWrite32(0x00625A2B + 2, var);
-	SafeWrite32(0x00625F70 + 1, var);
-	SafeWrite32(0x00755A21 + 1, var);
-	SafeWrite32(0x00755C49 + 1, var);
-	SafeWrite32(0x00B87313 + 1, var2);
-	SafeWrite32(0x00B87313 + 1, var2);
-
-
 
 	float correctionFactor = 1.777777777777778f / aspectRatio;
 

--- a/Monkey Patch/Render/Render2D.cpp
+++ b/Monkey Patch/Render/Render2D.cpp
@@ -214,13 +214,14 @@ bool UltrawideFix = false;
 // Clippy TODO, maybe handle 16:10?
 std::thread RefreshHUD_thread;
 void RefreshHUD_loop() {
+	Logger::TypedLog(CHN_DEBUG, "SR2Ultrawide Refreshing HUD %d\n",2);
 	vint_create_process_hook.enable();
 	std::this_thread::sleep_for(std::chrono::seconds(4));
 	vint_create_process_hook.disable();
 }
 
 char SR2Ultrawide_HUDScale() {
-	
+	Logger::TypedLog(CHN_DEBUG, "SR2Ultrawide Refreshing HUD %d\n", 1);
 	float currentX = (float)(*(unsigned int*)0x022f63f8);
 	float currentY = (float)(*(unsigned int*)0x022f63fc);
 	char result;
@@ -242,7 +243,7 @@ char SR2Ultrawide_HUDScale() {
 	SafeWrite32(0x00625D09 + 2, (UInt32)&var2);
 	SafeWrite32(0x0062597F + 2, (UInt32)&var2);
 
-
+	Logger::TypedLog(CHN_DEBUG, "SR2Ultrawide Refreshing HUD %d\n", 3);
 		RefreshHUD_thread = std::thread(RefreshHUD_loop);
 		RefreshHUD_thread.detach();
 
@@ -264,6 +265,7 @@ char SR2Ultrawide_HUDScale() {
 #if JLITE
 			General::luaLoadBuffHook.enable();
 #endif
+			Logger::TypedLog(CHN_DEBUG, "SR2Ultrawide Refreshing HUD %d\n", 4);
 			General::cleanupBufferHook.enable();
 			UltrawideFix = true;
 		}

--- a/Monkey Patch/Render/Render2D.cpp
+++ b/Monkey Patch/Render/Render2D.cpp
@@ -10,6 +10,7 @@
 #include "Render2D.h"
 #include <safetyhook.hpp>
 #include "..\General\General.h"
+#include "Render3D.h"
 namespace Render2D
 {
 	float* currentAR = (float*)0x022FD8EC;
@@ -218,6 +219,9 @@ char SR2Ultrawide_HUDScale() {
 	char result;
 
 	float aspectRatio = currentX / currentY;
+	if (aspectRatio >= 1.79777777778) {
+		Render3D::AspectRatioFix(aspectRatio,true);
+	}
 	if (!vint_create_process_hook.enabled()) {
 		if (aspectRatio <= 1.79777777778) {
 #if JLITE

--- a/Monkey Patch/Render/Render2D.cpp
+++ b/Monkey Patch/Render/Render2D.cpp
@@ -219,11 +219,11 @@ char SR2Ultrawide_HUDScale() {
 	char result;
 
 	float aspectRatio = currentX / currentY;
-	if (aspectRatio >= 1.79777777778) {
-		Render3D::AspectRatioFix(aspectRatio,true);
+	if (aspectRatio >= 1.79777777778f) {
+		Render3D::AspectRatioFix(true);
 	}
 	if (!vint_create_process_hook.enabled()) {
-		if (aspectRatio <= 1.79777777778) {
+		if (aspectRatio <= 1.79777777778f) {
 #if JLITE
 			General::luaLoadBuffHook.disable();
 #endif

--- a/Monkey Patch/Render/Render2D.cpp
+++ b/Monkey Patch/Render/Render2D.cpp
@@ -210,7 +210,7 @@ namespace Render2D
 	}
 
 bool UltrawideFix = false;
-
+// Clippy TODO, maybe handle 16:10?
 char SR2Ultrawide_HUDScale() {
 	
 	float currentX = (float)(*(unsigned int*)0x022f63f8);
@@ -221,16 +221,19 @@ char SR2Ultrawide_HUDScale() {
 	if (!vint_create_process_hook.enabled()) {
 		if (aspectRatio <= 1.79777777778) {
 			UltrawideFix = false;
+			General::cleanupBufferHook.disable();
+			General::CleanupModifiedScript();
 			return ((char(*)())0xD1C910)(); // Original HUD scale function.
+			
 		}
 		else {
-			static SafetyHookMid cleanupBufferHook = safetyhook::create_mid(0x00CDE388, [](safetyhook::Context32& ctx) {
-				General::CleanupModifiedScript();
-				});
+			General::cleanupBufferHook.enable();
 			UltrawideFix = true;
 		}
 	}
-	printf("Bruh %d \n", UltrawideFix);
+
+	// Fucking tagging system cause yeah lets hard code the anchor for it?
+
 	int var = (int)(aspectRatio * 720.f);
 	int var2 = (int)(aspectRatio * 360.f);
 	SafeWrite32(0x00622571 + 1, var);
@@ -241,7 +244,7 @@ char SR2Ultrawide_HUDScale() {
 	SafeWrite32(0x00B87313 + 1, var2);
 	SafeWrite32(0x00B87313 + 1, var2);
 
-	printf("var1: %d, var2: %d \n", var, var2);
+
 
 	float correctionFactor = 1.777777777777778f / aspectRatio;
 
@@ -262,7 +265,7 @@ char SR2Ultrawide_HUDScale() {
 		*(float*)0x022fdcc0 = adjustedX;
 		*(float*)0x022fdcbc = currentY / 720.0f;
 	}
-
+	Logger::TypedLog(CHN_MOD, "SR2Ultrawide patched HUD scale X: %f Y: %f bool: %d \n", adjustedX, currentY / 720.0f, UltrawideFix);
 	return result;
 }
 	void Init() {

--- a/Monkey Patch/Render/Render2D.cpp
+++ b/Monkey Patch/Render/Render2D.cpp
@@ -220,6 +220,9 @@ char SR2Ultrawide_HUDScale() {
 	float aspectRatio = currentX / currentY;
 	if (!vint_create_process_hook.enabled()) {
 		if (aspectRatio <= 1.79777777778) {
+#if JLITE
+			General::luaLoadBuffHook.disable();
+#endif
 			UltrawideFix = false;
 			General::cleanupBufferHook.disable();
 			General::CleanupModifiedScript();
@@ -227,6 +230,9 @@ char SR2Ultrawide_HUDScale() {
 			
 		}
 		else {
+#if JLITE
+			General::luaLoadBuffHook.enable();
+#endif
 			General::cleanupBufferHook.enable();
 			UltrawideFix = true;
 		}

--- a/Monkey Patch/Render/Render2D.h
+++ b/Monkey Patch/Render/Render2D.h
@@ -10,4 +10,36 @@ namespace Render2D
     extern void InGamePrint(const char* Text, int x, int y, int font);
 
     extern bool BetterChatTest;
+
+	enum vint_variant_type : __int32
+	{
+		VINT_PROP_TYPE_NONE = 0x0,
+		VINT_PROP_TYPE_INT = 0x1,
+		VINT_PROP_TYPE_UINT = 0x2,
+		VINT_PROP_TYPE_FLOAT = 0x3,
+		VINT_PROP_TYPE_STRING = 0x4,
+		VINT_PROP_TYPE_BOOL = 0x5,
+		VINT_PROP_TYPE_COLOR = 0x6,
+		VINT_PROP_TYPE_VECTOR2F = 0x7,
+		VINT_PROP_TYPE_CALLBACK = 0x8,
+		VINT_PROP_TYPE_DOCUMENT = 0x9,
+		VINT_PROP_TYPE_BITMAP = 0xA,
+		VINT_PROP_TYPE_FONT = 0xB,
+		VINT_PROP_TYPE_SOUND = 0xC,
+		VINT_PROP_LAST_VALID_FOR_VARIANT = 0xC,
+		VINT_PROP_TYPE_ENUM = 0xD,
+		VINT_PROP_TYPE_VARIABLE = 0xE,
+		NUM_VINT_PROP_TYPES = 0xF,
+	};
+
+	union __declspec(align(4)) vint_variant_values
+	{
+		float x;
+		float y;
+		// and more.
+	};
+	struct vint_variant {
+		vint_variant_type type;
+		vint_variant_values values;
+	};
 }

--- a/Monkey Patch/Render/Render2D.h
+++ b/Monkey Patch/Render/Render2D.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <safetyhook.hpp>
 namespace Render2D
 {
     typedef float(__cdecl* ChangeTextColorT)(int R, int G, int B, int Alpha);
@@ -42,4 +43,11 @@ namespace Render2D
 		vint_variant_type type;
 		vint_variant_values values;
 	};
+	extern const float widescreenvalue;
+	extern float* currentAR;
+	extern bool UltrawideFix;
+	extern float get_vint_x_resolution();
+	extern char SR2Ultrawide_HUDScale();
+	extern SafetyHookMid vint_create_process_hook;
+	extern void create_process_hook(safetyhook::Context32& ctx);
 }

--- a/Monkey Patch/Render/Render3D.cpp
+++ b/Monkey Patch/Render/Render3D.cpp
@@ -27,7 +27,8 @@ namespace Render3D
 	double FOVMultiplier = 1;
 	const double fourbythreeAR = 1.333333373069763;
 
-	void AspectRatioFix(float currentAR, bool update_aspect_ratio) {
+	void AspectRatioFix(bool update_aspect_ratio) {
+		float currentAR = *(float*)0x022FD8EC;
 		const float a169 = 1.777777791;
 		const double defaultFOV = 1.33333337306976;
 		//double currentFOV = *(double*)0x0E5C808;

--- a/Monkey Patch/Render/Render3D.cpp
+++ b/Monkey Patch/Render/Render3D.cpp
@@ -27,6 +27,39 @@ namespace Render3D
 	double FOVMultiplier = 1;
 	const double fourbythreeAR = 1.333333373069763;
 
+	void AspectRatioFix(float currentAR, bool update_aspect_ratio) {
+		const float a169 = 1.777777791;
+		const double defaultFOV = 1.33333337306976;
+		//double currentFOV = *(double*)0x0E5C808;
+		double correctFOV = (defaultFOV * ((double)currentAR / (double)a169));
+		correctFOV *= Render3D::FOVMultiplier;
+		if (currentAR > a169 && Render3D::ARfov && update_aspect_ratio) { // otherwise causes issues for odd ARs like 16:10/5:4 and the common 4:3.
+			patchDouble((BYTE*)0x00E5C808, correctFOV);
+			patchNop((BYTE*)0x00797181, 6); // Crosshair location that is read from FOV, we'll replace with our own logic below.
+			patchFloat((BYTE*)0x00EC2614, correctFOV);
+			Logger::TypedLog(CHN_DEBUG, "Aspect Ratio FOV fixed...\n");
+
+			if (Render3D::ARCutscene) {
+				static double correctCFOV = 57.2957795131 * ((double)currentAR / (double)a169);
+				if (correctCFOV > 125) {
+					correctCFOV = 125; // arbiratry number close to 32:9 CFOV, 
+					//this will stop most scenes from going upside down in 48:9, we need a beter address for cutscenes similiar to world FOV.
+				}
+				patchDWord((BYTE*)0x00494DE8 + 2, (uint32_t)&correctCFOV);
+				Logger::TypedLog(CHN_DEBUG, "Aspect Ratio Cutscenes (might break above 21:9) hack...\n");
+				Render3D::ARCutscene = 0;
+
+			}
+		}
+
+			double multipliedFOV = correctFOV * Render3D::FOVMultiplier;
+			patchDouble((BYTE*)0x00E5C808, multipliedFOV);
+			patchNop((BYTE*)0x00797181, 6);
+			patchFloat((BYTE*)0x00EC2614, (float)multipliedFOV);
+		
+		return;
+
+	}
 	void __declspec(naked) LoadShadersHook() {
 		static int Continue = 0x00D1B7D3;
 		static int* ShaderPointer;

--- a/Monkey Patch/Render/Render3D.h
+++ b/Monkey Patch/Render/Render3D.h
@@ -30,5 +30,5 @@ namespace Render3D
     extern CMultiPatch CMPatches_ClippysIdiotTextureCrashExceptionHandle;
     extern bool crash;
     extern SafetyHookMid add_to_entry_test;
-    extern void AspectRatioFix(float currentAR = 1.777777791f, bool update_aspect_ratio = false);
+    extern void AspectRatioFix(bool update_aspect_ratio = false);
 }

--- a/Monkey Patch/Render/Render3D.h
+++ b/Monkey Patch/Render/Render3D.h
@@ -30,4 +30,5 @@ namespace Render3D
     extern CMultiPatch CMPatches_ClippysIdiotTextureCrashExceptionHandle;
     extern bool crash;
     extern SafetyHookMid add_to_entry_test;
+    extern void AspectRatioFix(float currentAR = 1.777777791f, bool update_aspect_ratio = false);
 }


### PR DESCRIPTION
This is simply just my [SR2Ultrawide](https://www.saintsrowmods.com/forum/threads/sr2ultrawide-r1-3-pc-console.21430/) mod, which was a 2 step process of hooking the HUD scale function that was setup by CDPB, and then anchoring safe_frame in the lua files.

this PR gets my hooked HUD scale function from the mod but then modifies the LUA scripts in runtime when loaded dynamically, a new buffer is allocated for each call and then it's deleted after the call,

otherwise users can choose a loop for when each vint_document is processed but that's less than ideal.

Ideally we'd hook the rl_draw 2D function wherever it is and however it works.

![image](https://github.com/user-attachments/assets/4c5d2165-9cae-407f-abf5-b2ceff2c5532)
